### PR TITLE
Bring back upstream code for release APK check

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/NewVersionWorker.kt
+++ b/app/src/main/java/org/schabi/newpipe/NewVersionWorker.kt
@@ -20,6 +20,7 @@ import org.schabi.newpipe.extractor.downloader.Response
 import org.schabi.newpipe.extractor.exceptions.ReCaptchaException
 import org.schabi.newpipe.util.ReleaseVersionUtil.coerceUpdateCheckExpiry
 import org.schabi.newpipe.util.ReleaseVersionUtil.isLastUpdateCheckExpired
+import org.schabi.newpipe.util.ReleaseVersionUtil.isReleaseApk
 import org.schabi.newpipe.util.Version
 import java.io.IOException
 
@@ -69,6 +70,11 @@ class NewVersionWorker(
 
     @Throws(IOException::class, ReCaptchaException::class)
     private fun checkNewVersion() {
+        // Check if the current apk is a github one or not.
+        if (!isReleaseApk()) {
+            return
+        }
+
         val prefs = PreferenceManager.getDefaultSharedPreferences(applicationContext)
         // Check if the last request has happened a certain time ago
         // to reduce the number of API requests.

--- a/app/src/main/java/org/schabi/newpipe/settings/MainSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/MainSettingsFragment.java
@@ -9,6 +9,7 @@ import androidx.annotation.NonNull;
 
 import org.schabi.newpipe.MainActivity;
 import org.schabi.newpipe.R;
+import org.schabi.newpipe.util.ReleaseVersionUtil;
 
 public class MainSettingsFragment extends BasePreferenceFragment {
     public static final boolean DEBUG = MainActivity.DEBUG;
@@ -20,6 +21,14 @@ public class MainSettingsFragment extends BasePreferenceFragment {
         addPreferencesFromResourceRegistry();
 
         setHasOptionsMenu(true); // Otherwise onCreateOptionsMenu is not called
+
+        // Check if the app is updatable
+        if (!ReleaseVersionUtil.isReleaseApk()) {
+            getPreferenceScreen().removePreference(
+                    findPreference(getString(R.string.update_pref_screen_key)));
+
+            defaultPreferences.edit().putBoolean(getString(R.string.update_app_key), false).apply();
+        }
 
         // Hide debug preferences in RELEASE build variant
         if (!DEBUG) {

--- a/app/src/main/java/org/schabi/newpipe/util/ReleaseVersionUtil.kt
+++ b/app/src/main/java/org/schabi/newpipe/util/ReleaseVersionUtil.kt
@@ -22,7 +22,7 @@ import java.time.format.DateTimeFormatter
 object ReleaseVersionUtil {
     // Public key of the certificate that is used in NewPipe release versions
     private const val RELEASE_CERT_PUBLIC_KEY_SHA1 =
-        "B0:2E:90:7C:1C:D6:FC:57:C3:35:F0:88:D0:8F:50:5F:94:E4:D2:15"
+        "7F:46:0D:D0:6A:2D:A0:6B:57:B5:2C:ED:73:06:B7:87:43:90:66:A9"
 
     @JvmStatic
     fun isReleaseApk(): Boolean {


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

Upstream code checks whether the current APK was signed with the release
key for various reasons:
- in order to show/hide the "Updates" settings menu
- in order to make the "Updates" settings menu searchable or not
- in order to check/not check for updates at the application start

This behavior was removed in NewPipe SponsorBlock fork, but it probably
shouldn't have been:

- the newer APK installation won't work if the locally installed APK
  wasn't signed with the same key
- `isReleaseApk` function was still invoked in NewPipe SponsorBlock to
  allow searching "Updates" settings from settings menu. But as the
  fingerprint wasn't correct, the update settings would not be searchable
  which is a bug
- this is a requirement for F-Droid inclusion as they sign their APKs
  with their own keys (so the updater wouldn't work) and they explicitly
  forbid auto-updaters by policy (see also #8)

This PR brings back all these checks (byte-by-byte with upstream to
make maintaining the fork easier). For this to work properly, it is
obviously needed to use NewPipe Sponsorblock's release key fingerprint
(instead of the upstream one). Therefore, this PR also updates it. It can be
retrieved using the following command:

```console
  $ keytool -printcert -file CERT.RSA | grep SHA1
```

Or if you own the keystore, directly:

```console
  $ keytool -v -list -keystore my-release-key.keystore -alias <alias_name> | grep SHA1
```
(setting the expected value for <alias_name>)

#### Before/After Screenshots/Screen Record

- N/A

#### Fixes the following issue(s)

- Required by #8 (I don't think there is any other blocker for F-Droid inclusion, so I let you decide if you want to close this issue or not)
- Fixes a bug where the `Check updates` settings weren't searchable in this fork.

#### APK testing 

Not relevant here as I obviously don't have enough money to spend to find a SHA-1 collision yet. Though I tested with a self-signed APK and I can attest that it does what's expected.

#### Due diligence

- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
