### PR TITLE
Attempt to fix crash by RYD showing dislike info while screen is being rotated

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -1547,11 +1547,18 @@ public final class VideoDetailFragment
                 new Thread(() -> {
                     info.setDislikeCount(ReturnYouTubeDislikeUtils.getDislikes(getContext(), info));
                     if (info.getDislikeCount() >= 0) {
+                        if (activity == null) {
+                            return;
+                        }
                         activity.runOnUiThread(() -> {
-                            binding.detailThumbsDownCountView.setText(Localization
-                                    .shortCount(activity, info.getDislikeCount()));
-                            binding.detailThumbsDownCountView.setVisibility(View.VISIBLE);
-                            binding.detailThumbsDownImgView.setVisibility(View.VISIBLE);
+                            if (binding != null && binding.detailThumbsDownCountView != null) {
+                                binding.detailThumbsDownCountView.setText(Localization
+                                        .shortCount(activity, info.getDislikeCount()));
+                                binding.detailThumbsDownCountView.setVisibility(View.VISIBLE);
+                            }
+                            if (binding != null && binding.detailThumbsDownImgView != null) {
+                                binding.detailThumbsDownImgView.setVisibility(View.VISIBLE);
+                            }
                         });
                     }
                 }).start();


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
Adds null checks when attempting to run code on the UI thread and showing dislike information from Return Youtube Dislike

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
(In my experience, I can more consistently reproduce the bug by manually fullscreening the video right after it loads, hence me mashing on where the fullscreen button would be)
- Before:

https://user-images.githubusercontent.com/45762106/218317878-d83ee664-5dd7-43a1-8c29-7ed46aebf82b.mp4
- After:

https://user-images.githubusercontent.com/45762106/218317899-4ea44ea9-7426-4fd2-8afe-ab10c11903c9.mp4

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #297

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
