### PR TITLE
sponsorblock: use serviceId instead of string comparison to determine…

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/ReturnYouTubeDislikeUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ReturnYouTubeDislikeUtils.java
@@ -12,6 +12,7 @@ import com.grack.nanojson.JsonParser;
 import org.schabi.newpipe.DownloaderImpl;
 import org.schabi.newpipe.MainActivity;
 import org.schabi.newpipe.R;
+import org.schabi.newpipe.extractor.ServiceList;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 
 public final class ReturnYouTubeDislikeUtils {
@@ -35,7 +36,7 @@ public final class ReturnYouTubeDislikeUtils {
             return -1;
         }
 
-        if (!streamInfo.getUrl().startsWith("https://www.youtube.com")) {
+        if (streamInfo.getServiceId() != ServiceList.YouTube.getServiceId()) {
             return -1;
         }
 

--- a/app/src/main/java/org/schabi/newpipe/util/SponsorBlockUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/SponsorBlockUtils.java
@@ -18,6 +18,7 @@ import org.schabi.newpipe.App;
 import org.schabi.newpipe.DownloaderImpl;
 import org.schabi.newpipe.MainActivity;
 import org.schabi.newpipe.R;
+import org.schabi.newpipe.extractor.ServiceList;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.player.playqueue.PlayQueueItem;
 import org.schabi.newpipe.views.MarkableSeekBar;
@@ -53,7 +54,7 @@ public final class SponsorBlockUtils {
         final String apiUrl = prefs.getString(context
                 .getString(R.string.sponsor_block_api_url_key), null);
 
-        if (!streamInfo.getUrl().startsWith("https://www.youtube.com")
+        if (streamInfo.getServiceId() != ServiceList.YouTube.getServiceId()
                 || apiUrl == null
                 || apiUrl.isEmpty()) {
             return null;


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- instead of using string to determine if the youtube service is used use the serviceId


#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
