### PR TITLE
sponsorblock: cache to prevent fetching same VideoSegment information…

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/SponsorBlockUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/SponsorBlockUtils.java
@@ -28,11 +28,14 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 public final class SponsorBlockUtils {
     private static final Application APP = App.getApp();
     private static final String TAG = SponsorBlockUtils.class.getSimpleName();
     private static final boolean DEBUG = MainActivity.DEBUG;
+    private static Map<String, VideoSegment[]> videoSegmentsCache = new HashMap<>();
 
     private SponsorBlockUtils() {
     }
@@ -120,6 +123,11 @@ public final class SponsorBlockUtils {
         final String params = "skipSegments/" + videoIdHash.substring(0, 4)
                 + "?categories=" + categoryParams;
 
+        final VideoSegment[] alreadyFetchedVideoSegments = videoSegmentsCache.get(params);
+        if (alreadyFetchedVideoSegments != null) {
+            return alreadyFetchedVideoSegments;
+        }
+
         if (!isConnected()) {
             return null;
         }
@@ -177,8 +185,9 @@ public final class SponsorBlockUtils {
                 result.add(segment);
             }
         }
-
-        return result.toArray(new VideoSegment[0]);
+        final VideoSegment[] segments = result.toArray(new VideoSegment[0]);
+        videoSegmentsCache.put(params, segments);
+        return segments;
     }
 
     private static boolean isConnected() {


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- cache VideoSegments for given video sponsorblock params
- prevent fetching same information for download or screen rotation again.


#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
