### PR TITLE
sponsorblock: move fetching VideoSegment's to DownloadDialog

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -1,6 +1,7 @@
 package org.schabi.newpipe.download;
 
 import static org.schabi.newpipe.extractor.stream.DeliveryMethod.PROGRESSIVE_HTTP;
+import static org.schabi.newpipe.ktx.ViewUtils.animate;
 import static org.schabi.newpipe.util.ListHelper.getStreamsOfSpecifiedDelivery;
 import static org.schabi.newpipe.util.Localization.assureCorrectAppLanguage;
 
@@ -66,6 +67,7 @@ import org.schabi.newpipe.util.ListHelper;
 import org.schabi.newpipe.util.PermissionHelper;
 import org.schabi.newpipe.util.SecondaryStreamHelper;
 import org.schabi.newpipe.util.SimpleOnSeekBarChangeListener;
+import org.schabi.newpipe.util.SponsorBlockUtils;
 import org.schabi.newpipe.util.StreamItemAdapter;
 import org.schabi.newpipe.util.StreamItemAdapter.StreamSizeWrapper;
 import org.schabi.newpipe.util.ThemeHelper;
@@ -80,7 +82,10 @@ import java.util.Optional;
 
 import icepick.Icepick;
 import icepick.State;
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
+import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 import us.shandian.giga.get.MissionRecoveryInfo;
 import us.shandian.giga.postprocessing.Postprocessing;
 import us.shandian.giga.service.DownloadManager;
@@ -260,7 +265,7 @@ public class DownloadDialog extends DialogFragment
                 downloadManager = mgr.getDownloadManager();
                 askForSavePath = mgr.askForSavePath();
 
-                okButton.setEnabled(true);
+                checkForYoutubeVideoSegments();
 
                 context.unbindService(this);
             }
@@ -300,6 +305,8 @@ public class DownloadDialog extends DialogFragment
         dialogBinding.qualitySpinner.setOnItemSelectedListener(this);
 
         dialogBinding.videoAudioGroup.setOnCheckedChangeListener(this);
+
+        showLoading();
 
         initToolbar(dialogBinding.toolbarLayout.toolbar);
         setupDownloadOptions();
@@ -1076,5 +1083,38 @@ public class DownloadDialog extends DialogFragment
                 Toast.LENGTH_SHORT).show();
 
         dismiss();
+    }
+
+    private void checkForYoutubeVideoSegments() {
+        disposables.add(Single.fromCallable(() -> {
+                    VideoSegment[] videoSegments = null;
+                    try {
+                        videoSegments = SponsorBlockUtils
+                                .getYouTubeVideoSegments(getContext(), currentInfo);
+                    } catch (final Exception e) {
+                        // TODO: handle?
+                    }
+
+                    return videoSegments == null
+                            ? new VideoSegment[0]
+                            : videoSegments;
+                })
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(videoSegments -> {
+                    setVideoSegments(videoSegments);
+                    okButton.setEnabled(true);
+                    hideLoading();
+                }));
+    }
+
+    public void showLoading() {
+        dialogBinding.fileName.setVisibility(View.GONE);
+        animate(dialogBinding.loadingProgressBar, true, 400);
+    }
+
+    public void hideLoading() {
+        animate(dialogBinding.loadingProgressBar, false, 0);
+        dialogBinding.fileName.setVisibility(View.VISIBLE);
     }
 }

--- a/app/src/main/res/layout/download_dialog.xml
+++ b/app/src/main/res/layout/download_dialog.xml
@@ -18,16 +18,28 @@
         android:layout_marginBottom="6dp"
         android:text="@string/msg_name" />
 
+    <ProgressBar
+        android:id="@+id/loading_progress_bar"
+        style="@style/Widget.AppCompat.ProgressBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/file_name_text_view"
+        android:indeterminate="true"
+        android:visibility="gone"
+        tools:visibility="visible" />
+
     <org.schabi.newpipe.views.NewPipeEditText
         android:id="@+id/file_name"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/file_name_text_view"
+        android:layout_below="@id/loading_progress_bar"
         android:layout_marginLeft="20dp"
         android:layout_marginRight="20dp"
         android:layout_marginBottom="6dp"
         android:inputType="text"
-        android:maxLines="1" />
+        android:maxLines="1"
+        android:visibility="gone"
+        tools:visibility="visible" />
 
     <RadioGroup
         android:id="@+id/video_audio_group"


### PR DESCRIPTION
Pushing download button for a video sometimes takes for ages.
This PR moves Sponsorblock VideoSegment logic to DownloadDialog.
#### What is it?
- [ ] Bugfix (user facing)
- [X] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- move fetching VideoSegment's to DownloadDialog
- integrate ProgressBar to show that we are fetching VideoSegment's

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
