### PR TITLE
fix DownloadDialog crash if there are no streams available yet

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -87,6 +87,7 @@ import icepick.State;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
+import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import us.shandian.giga.get.MissionRecoveryInfo;
 import us.shandian.giga.postprocessing.Postprocessing;
@@ -153,6 +154,8 @@ public class DownloadDialog extends DialogFragment
     private final ActivityResultLauncher<Intent> requestDownloadPickVideoFolderLauncher =
             registerForActivityResult(
                     new StartActivityForResult(), this::requestDownloadPickVideoFolderResult);
+    @NonNull
+    private Disposable youtubeVideoSegmentsDisposable;
 
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -254,8 +257,6 @@ public class DownloadDialog extends DialogFragment
                 downloadManager = mgr.getDownloadManager();
                 askForSavePath = mgr.askForSavePath();
 
-                checkForYoutubeVideoSegments();
-
                 context.unbindService(this);
             }
 
@@ -332,6 +333,7 @@ public class DownloadDialog extends DialogFragment
         showLoading();
 
         initToolbar(dialogBinding.toolbarLayout.toolbar);
+        checkForYoutubeVideoSegments();
         setupDownloadOptions();
 
         prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
@@ -393,6 +395,7 @@ public class DownloadDialog extends DialogFragment
 
     @Override
     public void onDestroyView() {
+        youtubeVideoSegmentsDisposable.dispose();
         dialogBinding = null;
         super.onDestroyView();
     }
@@ -1158,7 +1161,7 @@ public class DownloadDialog extends DialogFragment
     }
 
     private void checkForYoutubeVideoSegments() {
-        disposables.add(Single.fromCallable(() -> {
+        youtubeVideoSegmentsDisposable = Single.fromCallable(() -> {
                     VideoSegment[] videoSegments = null;
                     try {
                         videoSegments = SponsorBlockUtils
@@ -1177,7 +1180,7 @@ public class DownloadDialog extends DialogFragment
                     setVideoSegments(videoSegments);
                     okButton.setEnabled(true);
                     hideLoading();
-                }));
+                });
     }
 
     public void showLoading() {


### PR DESCRIPTION
If there are no streams the DownloadDialog will close again quickly, but the rxJava job fetching the VideoSegments is still going. This patch fixes that:
- move initialization of getting VideoSegments rxJava job until after initToolbar()
- have Disposable for the VideoSegments stuff that will be disposed if the DownloadDialog will be destroyed.

<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
    fix DownloadDialog crash if there are now streams available yet
    
    If there are no streams the DownloadDialog will close again quickly,
    but the rxJava job fetching the VideoSegments is still going. This patch
    fixes that:
    - move initialization of getting VideoSegments rxJava job until after initToolbar()
    - have Disposable for the VideoSegments stuff that will be disposed if the
      DownloadDialog will be destroyed.

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
